### PR TITLE
feat/story-browser-ui

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -346,7 +346,7 @@ function App() {
 				let storyTemp = {
 					type: 'News',
 					title: story['title'],
-					preview: LoremIpsum,
+					preview: story['preview_text'],
 					tags: [story['language'], story['topic']],
 					difficulty: story['cefr_level']
 				}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import UserPool from "./UserPool";
 import Status from "./Status";
 
+import StoryList from './components/StoryList';
+
 const StyledBox = styled.div`
 	width: 80%;
 	margin: 20px auto; // Center the box horizontally with margin
@@ -254,6 +256,33 @@ const Login = () => {
 	)
 }
 
+
+const LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+const sampleStories = [
+	{
+		type: 'News',
+		title: 'Donald Trump gana las elecciones de 2024',
+		preview: 'En un histórico regreso político, Donald Trump aseguró la presidencia en las elecciones de 2024, derrotando a la Vicepresidenta Kamala Harris...',
+		tags: ['Spanish', 'Politics'],
+		difficulty: 'C2'
+	},
+	{
+		type: 'Story',
+		title: 'Una historia muy interesante sobre el baloncesto',
+		preview: LoremIpsum,
+		tags: ['Spanish', 'Basketball'],
+		difficulty: 'B1'
+	},
+	{
+		type: 'News',
+		title: '¡Squeak es tan genial!',
+		preview: LoremIpsum,
+		tags: ['Spanish', 'Finance'],
+		difficulty: 'A2'
+	}
+];
+
 function App() {
 	const [language, setLanguage] = useState('');
 	const [CEFRLevel, setCEFRLevel] = useState('');
@@ -332,6 +361,8 @@ function App() {
 			<StyledBox>
 				<Title>Squeak</Title>
 				<Subtitle>Comprehensive Input Made Easy!</Subtitle>
+
+				<StoryList stories={sampleStories} />
 
 				{/* Dropdown for language selection */}
 				<SelectField value={language} onChange={(e) => setLanguage(e.target.value)}>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,12 @@
 import './App.css';
-import { useState, useContext } from 'react';
+import { useState, useContext, useEffect } from 'react';
 import { Account, AccountContext } from './Account';
 import styled from 'styled-components';
 
 import UserPool from "./UserPool";
 import Status from "./Status";
 
-import StoryList from './components/StoryList';
+import StoryBrowser from './components/StoryBrowser';
 
 const StyledBox = styled.div`
 	width: 80%;
@@ -259,30 +259,6 @@ const Login = () => {
 
 const LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
-const sampleStories = [
-	{
-		type: 'News',
-		title: 'Donald Trump gana las elecciones de 2024',
-		preview: 'En un histórico regreso político, Donald Trump aseguró la presidencia en las elecciones de 2024, derrotando a la Vicepresidenta Kamala Harris...',
-		tags: ['Spanish', 'Politics'],
-		difficulty: 'C2'
-	},
-	{
-		type: 'Story',
-		title: 'Una historia muy interesante sobre el baloncesto',
-		preview: LoremIpsum,
-		tags: ['Spanish', 'Basketball'],
-		difficulty: 'B1'
-	},
-	{
-		type: 'News',
-		title: '¡Squeak es tan genial!',
-		preview: LoremIpsum,
-		tags: ['Spanish', 'Finance'],
-		difficulty: 'A2'
-	}
-];
-
 function App() {
 	const [language, setLanguage] = useState('');
 	const [CEFRLevel, setCEFRLevel] = useState('');
@@ -292,6 +268,8 @@ function App() {
 	const [loading, setLoading] = useState(false); // State to manage loading state
 
 	const [tooltip, setTooltip] = useState({ visible: false, word: '', top: 0, left: 0, definition: '' });
+
+	const [allStories, setAllStories] = useState([]);
 
 	const isFormComplete = language && CEFRLevel;
 	const apiBase = "https://api.squeak.today/";
@@ -351,6 +329,38 @@ function App() {
 		setTooltip({ visible: false, word: '', top: 0, left: 0, definition: '' });
 	};
 
+	const handleListStories = async (e, word) => {
+		const tempStories = [];
+		let difficulties = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
+		let storyTypes = ['News', 'Story'];
+		let topics = ['Politics'];
+		let languages = ['French'];
+		for (let i=0; i<difficulties.length; i++) {
+			for (let j=0; j<storyTypes.length; j++) {
+				for (let k=0; k<topics.length; k++) {
+					for (let l=0; l<languages.length; l++) {
+						let randomPercent = Math.random();
+						let lengthToTake = Math.floor(LoremIpsum.length * randomPercent);
+						let mockPreview = LoremIpsum.substring(0, lengthToTake);
+						let storyTemp = {
+							type: storyTypes[j],
+							title: "A " + storyTypes[j] + " piece about " + topics[k],
+							preview: mockPreview,
+							tags: [languages[l], topics[k]],
+							difficulty: difficulties[i]
+						}
+						tempStories.push(storyTemp);
+					}	
+				}
+			}
+		}
+		setAllStories(tempStories);
+	};
+
+	useEffect(() => {
+		handleListStories();
+	}, []); // Empty dependency array means this runs once on mount
+
 	return (
 		<Account>
 			
@@ -362,7 +372,7 @@ function App() {
 				<Title>Squeak</Title>
 				<Subtitle>Comprehensive Input Made Easy!</Subtitle>
 
-				<StoryList stories={sampleStories} />
+				<StoryBrowser stories={allStories} />
 
 				{/* Dropdown for language selection */}
 				<SelectField value={language} onChange={(e) => setLanguage(e.target.value)}>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -257,8 +257,6 @@ const Login = () => {
 }
 
 
-const LoremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
-
 function App() {
 	const [language, setLanguage] = useState('');
 	const [CEFRLevel, setCEFRLevel] = useState('');

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -327,33 +327,41 @@ function App() {
 		setTooltip({ visible: false, word: '', top: 0, left: 0, definition: '' });
 	};
 
+	const fetchContent = async (endpoint, language, cefrLevel, subject) => {
+		const url = `${apiBase}${endpoint}?language=${language}&cefr=${cefrLevel}&subject=${subject}`;
+		const response = await fetch(url);
+		if (!response.ok) { throw new Error(`Failed to fetch from ${endpoint}`); }
+		return response.json();
+	};
+
 	const handleListStories = async (language, cefrLevel, subject) => {
 		const tempStories = [];
-		let url = `${apiBase}query?language=${language}&cefr=${cefrLevel}&subject=${subject}`;
-		console.log(url);
-		await fetch(url).then(response => {
-			if (!response.ok) {
-				throw new Error("Failed to fetch stories");
-			}
-			return response.json();
-		}).then(data => {
-			console.log("Fetched stories successfully!");
-			for (const i in data) {
-				const story = data[i];
-				console.log(story);
-				let storyTemp = {
+		try {
+			const newsData = await fetchContent('news-query', language, cefrLevel, subject);
+			const storiesData = await fetchContent('story-query', language, cefrLevel, subject);
+			console.log('Fetched content successfully!')
+			for (const story of newsData) {
+				tempStories.push({
 					type: 'News',
 					title: story['title'],
 					preview: story['preview_text'],
 					tags: [story['language'], story['topic']],
 					difficulty: story['cefr_level']
-				}
-				tempStories.push(storyTemp);
+				});
 			}
-		}).catch(error => {
-			console.error("Failed to fetch stories:", error);
-		})
-		setAllStories(tempStories);
+			for (const story of storiesData) {
+				tempStories.push({
+					type: 'Story',
+					title: story['title'],
+					preview: story['preview_text'],
+					tags: [story['language'], story['topic']],
+					difficulty: story['cefr_level']
+				});
+			}
+			setAllStories(tempStories);
+		} catch (error) {
+			console.error("Failed to fetch content:", error);
+		}
 	};
 
 	useEffect(() => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -329,36 +329,37 @@ function App() {
 		setTooltip({ visible: false, word: '', top: 0, left: 0, definition: '' });
 	};
 
-	const handleListStories = async (e, word) => {
+	const handleListStories = async (language, cefrLevel, subject) => {
 		const tempStories = [];
-		let difficulties = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
-		let storyTypes = ['News'];
-		let topics = ['Politics'];
-		let languages = ['French'];
-		for (let i=0; i<difficulties.length; i++) {
-			for (let j=0; j<storyTypes.length; j++) {
-				for (let k=0; k<topics.length; k++) {
-					for (let l=0; l<languages.length; l++) {
-						let randomPercent = Math.random();
-						let lengthToTake = Math.floor(LoremIpsum.length * randomPercent);
-						let mockPreview = LoremIpsum.substring(0, lengthToTake);
-						let storyTemp = {
-							type: storyTypes[j],
-							title: "A " + storyTypes[j] + " piece about " + topics[k],
-							preview: mockPreview,
-							tags: [languages[l], topics[k]],
-							difficulty: difficulties[i]
-						}
-						tempStories.push(storyTemp);
-					}	
-				}
+		let url = `${apiBase}query?language=${language}&cefr=${cefrLevel}&subject=${subject}`;
+		console.log(url);
+		await fetch(url).then(response => {
+			if (!response.ok) {
+				throw new Error("Failed to fetch stories");
 			}
-		}
+			return response.json();
+		}).then(data => {
+			console.log("Fetched stories successfully!");
+			for (const i in data) {
+				const story = data[i];
+				console.log(story);
+				let storyTemp = {
+					type: 'News',
+					title: story['title'],
+					preview: LoremIpsum,
+					tags: [story['language'], story['topic']],
+					difficulty: story['cefr_level']
+				}
+				tempStories.push(storyTemp);
+			}
+		}).catch(error => {
+			console.error("Failed to fetch stories:", error);
+		})
 		setAllStories(tempStories);
 	};
 
 	useEffect(() => {
-		handleListStories();
+		handleListStories('any', 'any', 'any');
 	}, []); // Empty dependency array means this runs once on mount
 
 	return (
@@ -372,7 +373,10 @@ function App() {
 				<Title>Squeak</Title>
 				<Subtitle>Comprehensive Input Made Easy!</Subtitle>
 
-				<StoryBrowser stories={allStories} />
+				<StoryBrowser 
+					stories={allStories} 
+					onParamsSelect={handleListStories} 
+				/>
 
 				{/* Dropdown for language selection */}
 				<SelectField value={language} onChange={(e) => setLanguage(e.target.value)}>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -332,7 +332,7 @@ function App() {
 	const handleListStories = async (e, word) => {
 		const tempStories = [];
 		let difficulties = ['A1', 'A2', 'B1', 'B2', 'C1', 'C2'];
-		let storyTypes = ['News', 'Story'];
+		let storyTypes = ['News'];
 		let topics = ['Politics'];
 		let languages = ['French'];
 		for (let i=0; i<difficulties.length; i++) {

--- a/frontend/src/components/StoryBlock.js
+++ b/frontend/src/components/StoryBlock.js
@@ -1,0 +1,121 @@
+import styled from 'styled-components';
+
+const StoryBlockContainer = styled.div`
+	background: white;
+	border-radius: 15px;
+	padding: 1.25em;
+	margin: 1.25em 0;
+	cursor: pointer;
+	transition: transform 0.2s;
+	font-family: 'Noto Serif', serif;
+	position: relative;
+
+	&:hover {
+		transform: translateY(-2px);
+	}
+`;
+
+const getTypeColor = (type) => {
+	switch (type.toLowerCase()) {
+	case 'news':
+		return '#D4B5FF'; // brighter pastel purple
+	case 'story':
+		return '#99CCFF'; // brighter pastel blue
+	default:
+		return '#4A90E2';
+	}
+};
+
+const StoryType = styled.div`
+	display: inline-block;
+	padding: 0.3em 1em;
+	background: ${props => getTypeColor(props.type)};
+	color: black;
+	border-radius: 15px;
+	font-size: 0.875em;
+	font-family: 'Noto Serif', serif;
+	position: absolute;
+	top: -0.75em;
+	left: 1.25em;
+`;
+
+const Title = styled.h2`
+	margin: 0 0 0.625em 0;
+	font-size: 1.25em;
+	color: #333;
+	font-family: 'Noto Serif', serif;
+`;
+
+const ContentWrapper = styled.div`
+	margin-right: 6em;
+	margin-top: 0.5em;
+`;
+
+const Preview = styled.p`
+	color: #666;
+	font-size: 0.875em;
+	font-family: 'Noto Serif', serif;
+`;
+
+const TagContainer = styled.div`
+	display: flex;
+	gap: 0.625em;
+	font-family: 'Noto Serif', serif;
+`;
+
+const Tag = styled.span`
+	background: #E0E0E0;
+	padding: 0.25em 0.75em;
+	border-radius: 15px;
+	font-size: 0.75em;
+	color: #666;
+	font-family: 'Noto Serif', serif;
+`;
+
+const getCEFRColor = (level) => {
+	const firstLetter = level.charAt(0);
+	switch (firstLetter) {
+	case 'C':
+		return '#FFB3B3'; // pastel red
+	case 'B':
+		return '#FFD6B3'; // pastel orange
+	case 'A':
+		return '#B3FFB3'; // pastel green
+	default:
+		return '#FFA07A'; // default color
+	}
+};
+
+const CEFRLevel = styled.div`
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	right: 1.25em;
+	background: ${props => getCEFRColor(props.level)};
+	color: black;
+	padding: 0.625em 1.25em;
+	border-radius: 20px;
+	font-weight: bold;
+	font-size: 1em;
+	font-family: 'Noto Serif', serif;
+`;
+
+const StoryBlock = ({ type, title, preview, tags, difficulty }) => {
+	return (
+		<StoryBlockContainer>
+			<StoryType type={type}>{type}</StoryType>
+			<Title>{title}</Title>
+			<ContentWrapper>
+				<Preview>{preview}</Preview>
+				<TagContainer>
+					{tags.map((tag, index) => (
+						<Tag key={index}>{tag}</Tag>
+					))}
+				</TagContainer>
+			</ContentWrapper>
+			<CEFRLevel level={difficulty}>{difficulty}</CEFRLevel>
+		</StoryBlockContainer>
+	);
+};
+
+export default StoryBlock; 

--- a/frontend/src/components/StoryBrowser.js
+++ b/frontend/src/components/StoryBrowser.js
@@ -55,10 +55,10 @@ const PageButton = styled.button`
 	}
 `;
 
-const StoryBrowser = ({ stories }) => {
-	const [filterLanguage, setFilterLanguage] = useState('Any');
-	const [filterLevel, setFilterLevel] = useState('Any');
-	const [filterTopic, setFilterTopic] = useState('Any');
+const StoryBrowser = ({ stories, onParamsSelect }) => {
+	const [filterLanguage, setFilterLanguage] = useState('any');
+	const [filterLevel, setFilterLevel] = useState('any');
+	const [filterTopic, setFilterTopic] = useState('any');
 	const [currentPage, setCurrentPage] = useState(1);
 	const storiesPerPage = 6;
 
@@ -82,16 +82,9 @@ const StoryBrowser = ({ stories }) => {
 		return `${month} ${day}${getOrdinal(day)}, ${year}`;
 	};
 
-	const filteredStories = stories.filter(story => {
-		if (filterLanguage !== 'Any' && !story.tags.includes(filterLanguage)) return false;
-		if (filterLevel !== 'Any' && story.difficulty !== filterLevel) return false;
-		if (filterTopic !== 'Any' && !story.tags.includes(filterTopic)) return false;
-		return true;
-	});
-
 	// Then paginate the filtered stories
-	const totalPages = Math.ceil(filteredStories.length / storiesPerPage);
-	const paginatedStories = filteredStories.slice(
+	const totalPages = Math.ceil(stories.length / storiesPerPage);
+	const paginatedStories = stories.slice(
 		(currentPage - 1) * storiesPerPage,
 		currentPage * storiesPerPage
 	);
@@ -108,9 +101,9 @@ const StoryBrowser = ({ stories }) => {
 					<FilterLabel>Language</FilterLabel>
 					<FilterSelect 
 						value={filterLanguage} 
-						onChange={(e) => setFilterLanguage(e.target.value)}
+						onChange={(e) => { setFilterLanguage(e.target.value); onParamsSelect(e.target.value, filterLevel, filterTopic); }}
 					>
-						<option value="Any">Any Language</option>
+						<option value="any">Any Language</option>
 						<option value="Spanish">Spanish</option>
 						<option value="French">French</option>
 					</FilterSelect>
@@ -120,9 +113,9 @@ const StoryBrowser = ({ stories }) => {
 					<FilterLabel>Reading Level</FilterLabel>
 					<FilterSelect 
 						value={filterLevel} 
-						onChange={(e) => setFilterLevel(e.target.value)}
+						onChange={(e) => { setFilterLevel(e.target.value); onParamsSelect(filterLanguage, e.target.value, filterTopic); }}
 					>
-						<option value="Any">Any Level</option>
+						<option value="any">Any Level</option>
 						<option value="A1">A1</option>
 						<option value="A2">A2</option>
 						<option value="B1">B1</option>
@@ -136,16 +129,16 @@ const StoryBrowser = ({ stories }) => {
 					<FilterLabel>Topic</FilterLabel>
 					<FilterSelect 
 						value={filterTopic} 
-						onChange={(e) => setFilterTopic(e.target.value)}
+						onChange={(e) => { setFilterTopic(e.target.value); onParamsSelect(filterLanguage, filterLevel, e.target.value); }}
 					>
-						<option value="Any">Any Topic</option>
+						<option value="any">Any Topic</option>
 						<option value="Politics">Politics</option>
 						<option value="Basketball">Basketball</option>
 						<option value="Finance">Finance</option>
 					</FilterSelect>
 				</div>
 			</FilterContainer>
-
+			
 			<StoryList stories={paginatedStories} />
 
 			<PaginationContainer>

--- a/frontend/src/components/StoryBrowser.js
+++ b/frontend/src/components/StoryBrowser.js
@@ -34,10 +34,33 @@ const FilterSelect = styled.select`
 	cursor: pointer;
 `;
 
+const PaginationContainer = styled.div`
+	display: flex;
+	justify-content: center;
+	gap: 0.5em;
+	margin-top: 0.5em;
+`;
+
+const PageButton = styled.button`
+	padding: 0.5em 1em;
+	border: 1px solid white;
+	border-radius: 10px;
+	background: white;
+	cursor: pointer;
+	font-family: 'Noto Serif', serif;
+
+	&:disabled {
+		background: #eee;
+		cursor: not-allowed;
+	}
+`;
+
 const StoryBrowser = ({ stories }) => {
 	const [filterLanguage, setFilterLanguage] = useState('Any');
 	const [filterLevel, setFilterLevel] = useState('Any');
 	const [filterTopic, setFilterTopic] = useState('Any');
+	const [currentPage, setCurrentPage] = useState(1);
+	const storiesPerPage = 5;
 
 	const formatDate = () => {
 		const date = new Date();
@@ -65,6 +88,17 @@ const StoryBrowser = ({ stories }) => {
 		if (filterTopic !== 'Any' && !story.tags.includes(filterTopic)) return false;
 		return true;
 	});
+
+	// Then paginate the filtered stories
+	const totalPages = Math.ceil(filteredStories.length / storiesPerPage);
+	const paginatedStories = filteredStories.slice(
+		(currentPage - 1) * storiesPerPage,
+		currentPage * storiesPerPage
+	);
+
+	const handlePageChange = (page) => {
+		setCurrentPage(page);
+	};
 
 	return (
 		<div>
@@ -112,7 +146,38 @@ const StoryBrowser = ({ stories }) => {
 				</div>
 			</FilterContainer>
 
-			<StoryList stories={filteredStories} />
+			<StoryList stories={paginatedStories} />
+
+			<PaginationContainer>
+				<PageButton 
+					onClick={() => handlePageChange(1)} 
+					disabled={currentPage === 1}
+				>
+					First
+				</PageButton>
+				<PageButton 
+					onClick={() => handlePageChange(currentPage - 1)} 
+					disabled={currentPage === 1}
+				>
+					Previous
+				</PageButton>
+				{/* Show current page and total pages */}
+				<PageButton disabled>
+					{currentPage} of {totalPages}
+				</PageButton>
+				<PageButton 
+					onClick={() => handlePageChange(currentPage + 1)} 
+					disabled={currentPage === totalPages}
+				>
+					Next
+				</PageButton>
+				<PageButton 
+					onClick={() => handlePageChange(totalPages)} 
+					disabled={currentPage === totalPages}
+				>
+					Last
+				</PageButton>
+			</PaginationContainer>
 		</div>
 	);
 };

--- a/frontend/src/components/StoryBrowser.js
+++ b/frontend/src/components/StoryBrowser.js
@@ -60,7 +60,7 @@ const StoryBrowser = ({ stories }) => {
 	const [filterLevel, setFilterLevel] = useState('Any');
 	const [filterTopic, setFilterTopic] = useState('Any');
 	const [currentPage, setCurrentPage] = useState(1);
-	const storiesPerPage = 5;
+	const storiesPerPage = 6;
 
 	const formatDate = () => {
 		const date = new Date();

--- a/frontend/src/components/StoryBrowser.js
+++ b/frontend/src/components/StoryBrowser.js
@@ -1,0 +1,120 @@
+import styled from 'styled-components';
+import StoryList from './StoryList';
+import { useState } from 'react';
+
+const DateHeader = styled.h1`
+	font-family: 'Noto Serif', serif;
+	text-align: center;
+	margin-bottom: 1em;
+	font-size: 2em;
+	font-weight: 600;
+`;
+
+const FilterContainer = styled.div`
+	display: flex;
+	gap: 1em;
+	margin-bottom: 1.25em;
+	max-width: 800px;
+	margin: 0 auto 1.25em;
+`;
+
+const FilterLabel = styled.label`
+	display: block;
+	margin-bottom: 0.3em;
+	font-family: 'Noto Serif', serif;
+`;
+
+const FilterSelect = styled.select`
+	padding: 0.5em;
+	border: 1px solid white;
+	border-radius: 5px;
+	font-family: 'Noto Serif', serif;
+	width: 100%;
+	background: white;
+	cursor: pointer;
+`;
+
+const StoryBrowser = ({ stories }) => {
+	const [filterLanguage, setFilterLanguage] = useState('Any');
+	const [filterLevel, setFilterLevel] = useState('Any');
+	const [filterTopic, setFilterTopic] = useState('Any');
+
+	const formatDate = () => {
+		const date = new Date();
+		const month = date.toLocaleDateString('en-US', { month: 'long' });
+		const day = date.getDate();
+		const year = date.getFullYear();
+
+		// Get ordinal suffix for day
+		const getOrdinal = (n) => {
+			if (n > 3 && n < 21) return 'th';
+			switch (n % 10) {
+				case 1: return 'st';
+				case 2: return 'nd';
+				case 3: return 'rd';
+				default: return 'th';
+			}
+		};
+
+		return `${month} ${day}${getOrdinal(day)}, ${year}`;
+	};
+
+	const filteredStories = stories.filter(story => {
+		if (filterLanguage !== 'Any' && !story.tags.includes(filterLanguage)) return false;
+		if (filterLevel !== 'Any' && story.difficulty !== filterLevel) return false;
+		if (filterTopic !== 'Any' && !story.tags.includes(filterTopic)) return false;
+		return true;
+	});
+
+	return (
+		<div>
+			<DateHeader>Today is {formatDate()}.</DateHeader>
+			<FilterContainer>
+				<div style={{ flex: 1 }}>
+					<FilterLabel>Language</FilterLabel>
+					<FilterSelect 
+						value={filterLanguage} 
+						onChange={(e) => setFilterLanguage(e.target.value)}
+					>
+						<option value="Any">Any Language</option>
+						<option value="Spanish">Spanish</option>
+						<option value="French">French</option>
+					</FilterSelect>
+				</div>
+
+				<div style={{ flex: 1 }}>
+					<FilterLabel>Reading Level</FilterLabel>
+					<FilterSelect 
+						value={filterLevel} 
+						onChange={(e) => setFilterLevel(e.target.value)}
+					>
+						<option value="Any">Any Level</option>
+						<option value="A1">A1</option>
+						<option value="A2">A2</option>
+						<option value="B1">B1</option>
+						<option value="B2">B2</option>
+						<option value="C1">C1</option>
+						<option value="C2">C2</option>
+					</FilterSelect>
+				</div>
+
+				<div style={{ flex: 1 }}>
+					<FilterLabel>Topic</FilterLabel>
+					<FilterSelect 
+						value={filterTopic} 
+						onChange={(e) => setFilterTopic(e.target.value)}
+					>
+						<option value="Any">Any Topic</option>
+						<option value="Politics">Politics</option>
+						<option value="Basketball">Basketball</option>
+						<option value="Finance">Finance</option>
+					</FilterSelect>
+				</div>
+			</FilterContainer>
+
+			<StoryList stories={filteredStories} />
+		</div>
+	);
+};
+
+export default StoryBrowser; 

--- a/frontend/src/components/StoryList.js
+++ b/frontend/src/components/StoryList.js
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import StoryBlock from './StoryBlock';
+
+const ListContainer = styled.div`
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px;
+    font-family: 'Noto Serif', serif;
+`;
+
+const StoryList = ({ stories }) => {
+    return (
+        <ListContainer>
+            {stories.map((story, index) => (
+                <StoryBlock
+                    key={index}
+                    type={story.type}
+                    title={story.title}
+                    preview={story.preview}
+                    tags={story.tags}
+                    difficulty={story.difficulty}
+                />
+            ))}
+        </ListContainer>
+    );
+};
+
+export default StoryList; 


### PR DESCRIPTION
# description
Add paged list to view available stories with dropdown filters.

# details
Uses `news-query` and `story-query` endpoints to get a list via the dropdown filters, and then lists them.
Doesn't remove anything, only adds the browser that functions independent of everything else.