### PR TITLE
Bug: Forcing black font color to avoid mobile font color issue

### DIFF
--- a/frontend/src/styles/AuthPageStyles.js
+++ b/frontend/src/styles/AuthPageStyles.js
@@ -62,6 +62,7 @@ export const AuthButton = styled.button`
 	border-radius: 10px;
 	background: white;
 	cursor: pointer;
+	color: black;
 	font-family: 'Noto Serif', serif;
 	font-size: 16px;
 	transition: all 0.2s ease;


### PR DESCRIPTION
The color would show up as white making it seem as if there is no login button

![image](https://github.com/user-attachments/assets/995aec7d-5865-4917-a572-005f1ee7b14e)


Should be fixed now 