### PR TITLE
feat: Titles and Preview without markdown syntax

### DIFF
--- a/frontend/src/components/StoryBrowser.js
+++ b/frontend/src/components/StoryBrowser.js
@@ -85,9 +85,9 @@ const StoryBrowser = ({ stories, onParamsSelect, onStoryBlockClick, defaultLangu
 			</FilterContainer>
 			
 			{stories.length > 0 ? (
-				<StoryList stories={stories} onStoryBlockClick={onStoryBlockClick} />
+				<StoryList stories={stories} />
 			) : (
-				<NoContentMessage>No stories found for these filters!</NoContentMessage>
+				<NoContentMessage>No content found for these filters!</NoContentMessage>
 			)}
 
 			{stories.length > 0 && (

--- a/frontend/src/components/StoryList.js
+++ b/frontend/src/components/StoryList.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import StoryBlock from './StoryBlock';
-
+import { useNavigate } from 'react-router-dom';
 const ListContainer = styled.div`
     max-width: 800px;
     margin: 0 auto;
@@ -11,7 +11,13 @@ const ListContainer = styled.div`
     gap: 0.1rem;
 `;
 
-const StoryList = ({ stories, onStoryBlockClick }) => {
+const StoryList = ({ stories }) => {
+    const navigate = useNavigate();
+
+    const handleStoryBlockClick = async (story) => {
+        navigate(`/read/${story.type}/${story.id}`);
+    }
+
     return (
         <ListContainer>
             {stories.map((story, index) => (
@@ -23,7 +29,7 @@ const StoryList = ({ stories, onStoryBlockClick }) => {
                     tags={story.tags}
                     difficulty={story.difficulty}
                     date={story.date_created}
-                    onStoryBlockClick={() => { onStoryBlockClick(story) }}
+                    onStoryBlockClick={() => { handleStoryBlockClick(story) }}
                 />
             ))}
         </ListContainer>

--- a/frontend/src/pages/Learn.js
+++ b/frontend/src/pages/Learn.js
@@ -69,10 +69,6 @@ function Learn() {
 
 	const { getProfile, upsertProfile } = useProfileAPI();
 
-	const handleStoryBlockClick = async (story) => {
-		navigate(`/read/${story.type}/${story.id}`);
-	}
-
 	const handleListNews = useCallback(async (language, cefrLevel, subject, page, pagesize) => {
 		const tempStories = [];
 		try {
@@ -347,7 +343,6 @@ function Learn() {
 						<StoryBrowser 
 							stories={allStories} 
 							onParamsSelect={handleListNews} 
-							onStoryBlockClick={handleStoryBlockClick}
 							defaultLanguage={profile?.learning_language || 'any'}
 						/>
 						<StoryRecommendations recommendations={storyRecommendations} />

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -51,7 +51,7 @@ func generateTitleAndPreview(text string) (string, string) {
 	rawText := stripmd.Strip(text)
 
 	title := strings.Split(rawText, "\n")[0]
-	titleRunes := []rune(rawText)
+	titleRunes := []rune(title)
 	if len(titleRunes) > 140 { title = string(titleRunes[:140]) + "..." }
 
 	previewText := rawText

--- a/lambda/stripmd/strip.go
+++ b/lambda/stripmd/strip.go
@@ -1,0 +1,83 @@
+package stripmd
+
+// taken directly from
+// https://github.com/writeas/go-strip-markdown
+// saved just cause i did not want to install the package through a github repo that might
+// disappear
+// although its been up for 9 years so im the paranoid one
+
+import (
+	"regexp"
+)
+
+type Options struct {
+	SkipImages bool
+}
+
+var (
+	listLeadersReg = regexp.MustCompile(`(?m)^([\s\t]*)([\*\-\+]|\d\.)\s+`)
+
+	headerReg = regexp.MustCompile(`\n={2,}`)
+	strikeReg = regexp.MustCompile(`~~`)
+	codeReg   = regexp.MustCompile("`{3}" + `.*\n`)
+
+	htmlReg         = regexp.MustCompile("<(.*?)>")
+	emphReg         = regexp.MustCompile(`\*\*([^*]+)\*\*`)
+	emphReg2        = regexp.MustCompile(`\*([^*]+)\*`)
+	emphReg3        = regexp.MustCompile(`__([^_]+)__`)
+	emphReg4        = regexp.MustCompile(`_([^_]+)_`)
+	setextHeaderReg = regexp.MustCompile(`^[=\-]{2,}\s*$`)
+	footnotesReg    = regexp.MustCompile(`\[\^.+?\](\: .*?$)?`)
+	footnotes2Reg   = regexp.MustCompile(`\s{0,2}\[.*?\]: .*?$`)
+	imagesReg       = regexp.MustCompile(`\!\[(.*?)\]\s?[\[\(].*?[\]\)]`)
+	linksReg        = regexp.MustCompile(`\[(.*?)\][\[\(].*?[\]\)]`)
+	blockquoteReg   = regexp.MustCompile(`>\s*`)
+	refLinkReg      = regexp.MustCompile(`^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$`)
+	atxHeaderReg    = regexp.MustCompile(`(?m)^\#{1,6}\s*([^#]+)\s*(\#{1,6})?$`)
+	atxHeaderReg2   = regexp.MustCompile(`([\*_]{1,3})(\S.*?\S)?P1`)
+	atxHeaderReg3   = regexp.MustCompile("(?m)(`{3,})" + `(.*?)?P1`)
+	atxHeaderReg4   = regexp.MustCompile(`^-{3,}\s*$`)
+	atxHeaderReg5   = regexp.MustCompile("`(.+?)`")
+	atxHeaderReg6   = regexp.MustCompile(`\n{2,}`)
+)
+
+// Strip returns the given string sans any Markdown.
+// Where necessary, elements are replaced with their best textual forms, so
+// for example, hyperlinks are stripped of their URL and become only the link
+// text, and images lose their URL and become only the alt text.
+func Strip(s string) string {
+	return StripOptions(s, Options{})
+}
+
+func StripOptions(s string, opts Options) string {
+	res := s
+	res = listLeadersReg.ReplaceAllString(res, "$1")
+
+	res = headerReg.ReplaceAllString(res, "\n")
+	res = strikeReg.ReplaceAllString(res, "")
+	res = codeReg.ReplaceAllString(res, "")
+
+	res = emphReg.ReplaceAllString(res, "$1")
+	res = emphReg2.ReplaceAllString(res, "$1")
+	res = emphReg3.ReplaceAllString(res, "$1")
+	res = emphReg4.ReplaceAllString(res, "$1")
+	res = htmlReg.ReplaceAllString(res, "$1")
+	res = setextHeaderReg.ReplaceAllString(res, "")
+	res = footnotesReg.ReplaceAllString(res, "")
+	res = footnotes2Reg.ReplaceAllString(res, "")
+	if opts.SkipImages {
+		res = imagesReg.ReplaceAllString(res, "")
+	} else {
+		res = imagesReg.ReplaceAllString(res, "$1")
+	}
+	res = linksReg.ReplaceAllString(res, "$1")
+	res = blockquoteReg.ReplaceAllString(res, "  ")
+	res = refLinkReg.ReplaceAllString(res, "")
+	res = atxHeaderReg.ReplaceAllString(res, "$1")
+	res = atxHeaderReg2.ReplaceAllString(res, "$2")
+	res = atxHeaderReg3.ReplaceAllString(res, "$2")
+	res = atxHeaderReg4.ReplaceAllString(res, "")
+	res = atxHeaderReg5.ReplaceAllString(res, "$1")
+	res = atxHeaderReg6.ReplaceAllString(res, "\n\n")
+	return res
+}


### PR DESCRIPTION
Fix uploading of titles, previews so that they are now like this, no MD syntax
<img width="863" alt="Screenshot 2025-03-03 at 2 08 44 PM" src="https://github.com/user-attachments/assets/14a15858-fd46-4347-85ed-8a9a5fdf0306" />
